### PR TITLE
Analyze FPGA_TARGET_ARTIFACT parsing and stage generation

### DIFF
--- a/fpga_pipeline_generator/config/default.yaml
+++ b/fpga_pipeline_generator/config/default.yaml
@@ -17,7 +17,7 @@ stages:
 
 # Правила выполнения задач
 default_rules:
-  - if: "$CI_MERGE_REQUEST_ID"
+  - when: always
 
 # Переменные по умолчанию
 default_variables:

--- a/fpga_pipeline_generator/templates/job.j2
+++ b/fpga_pipeline_generator/templates/job.j2
@@ -8,6 +8,10 @@
 {% if rules %}
   rules:
 {% for rule in rules %}
+    {%- if rule.if is defined %}
     - if: "{{ rule.if }}"
+    {%- elif rule.when is defined %}
+    - when: "{{ rule.when }}"
+    {%- endif %}
 {%- endfor %}
 {%- endif %}


### PR DESCRIPTION
Change default CI/CD rules to `when: always` to ensure all generated jobs run under any condition.

---

[Open in Web](https://cursor.com/agents?id=bc-cb25ec0f-0c85-48c9-8775-977fa09a487a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cb25ec0f-0c85-48c9-8775-977fa09a487a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)