### PR TITLE
Add latest tag checkout for SEMVER_BUMP_FPGA

### DIFF
--- a/fpga_pipeline_generator/templates/job.j2
+++ b/fpga_pipeline_generator/templates/job.j2
@@ -16,6 +16,8 @@
     - git pull
     - git tag
     - git submodule update --init --recursive fpga/
+    - LATEST_TAG=$(git describe --tags "$(git rev-list --tags --max-count=1)")
+    - git checkout "$LATEST_TAG"
 {% endif %}
   script:
     - git submodule update --init --recursive


### PR DESCRIPTION
Add latest Git tag checkout to `before_script` when `SEMVER_BUMP_FPGA` is enabled.

---
<a href="https://cursor.com/background-agent?bcId=bc-00c7a330-9a1f-462f-97b1-2656e142aca0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-00c7a330-9a1f-462f-97b1-2656e142aca0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

